### PR TITLE
Social share

### DIFF
--- a/src/components/FileModal.vue
+++ b/src/components/FileModal.vue
@@ -84,6 +84,13 @@
 .text-lighter {
 	color: #768394;
 }
+
+.btn-copy-link {
+	border-top-right-radius: 4px;
+	border-bottom-right-radius: 4px;
+	font-size: 14px;
+	padding: 0 16px;
+}
 </style>
 
 <template>
@@ -95,351 +102,287 @@
 			role="dialog"
 			aria-labelledby="modalLabel"
 		>
-			<div
-				class="modal-dialog modal-xl modal-dialog-centered"
-				role="document"
-			>
+			<div class="modal-dialog modal-xl modal-dialog-centered" role="document">
 				<div class="modal-content">
 					<div class="modal-body p-0">
 						<div class="container-fluid p-0">
-							<div class="row">
-								<div class="col-6 col-lg-8">
-									<div
-										class="
-											file-preview-wrapper
-											d-flex
-											align-items-center
-										"
-									>
-										<img
-											class="preview img-fluid"
-											v-if="previewIsImage"
-											v-bind:src="preSignedUrl"
-										/>
 
-										<video
-											class="preview"
-											controls
-											v-if="previewIsVideo"
-											v-bind:src="preSignedUrl"
-										></video>
+						<div class="row">
+							<div class="col-6 col-lg-8">
+								<div class="file-preview-wrapper d-flex align-items-center">
 
-										<audio
-											class="preview"
-											controls
-											v-if="previewIsAudio"
-											v-bind:src="preSignedUrl"
-										></audio>
+									<img
+										class="preview img-fluid"
+										v-if="previewIsImage"
+										v-bind:src="preSignedUrl"
+									/>
 
-										<svg
-											v-if="isPlaceHolderDisplayable"
-											width="300"
-											height="172"
-											viewBox="0 0 300 172"
-											fill="none"
-											xmlns="http://www.w3.org/2000/svg"
-											class="
-												preview-placeholder
-												img-fluid
-												px-5
-												pb-5
-											"
-										>
-											<path
-												d="M188.5 140C218.047 140 242 116.047 242 86.5C242 56.9528 218.047 33 188.5 33C158.953 33 135 56.9528 135 86.5C135 116.047 158.953 140 188.5 140Z"
-												fill="white"
-											/>
-											<path
-												d="M123.5 167C147.524 167 167 147.524 167 123.5C167 99.4756 147.524 80 123.5 80C99.4756 80 80 99.4756 80 123.5C80 147.524 99.4756 167 123.5 167Z"
-												fill="white"
-											/>
-											<path
-												d="M71.5 49C78.9558 49 85 42.9558 85 35.5C85 28.0442 78.9558 22 71.5 22C64.0442 22 58 28.0442 58 35.5C58 42.9558 64.0442 49 71.5 49Z"
-												fill="white"
-											/>
-											<path
-												d="M262.5 143C268.851 143 274 137.851 274 131.5C274 125.149 268.851 120 262.5 120C256.149 120 251 125.149 251 131.5C251 137.851 256.149 143 262.5 143Z"
-												fill="white"
-											/>
-											<path
-												d="M185.638 64.338L191 57M153 109L179.458 72.7948L153 109Z"
-												stroke="#276CFF"
-												stroke-width="2"
-												stroke-linecap="round"
-											/>
-											<path
-												d="M121.08 153.429L115 161M153 108L127.16 144.343L153 108Z"
-												stroke="#276CFF"
-												stroke-width="2"
-												stroke-linecap="round"
-											/>
-											<path
-												d="M134 71L115 31M152 109L139 81L152 109Z"
-												stroke="#FF458B"
-												stroke-width="2"
-												stroke-linecap="round"
-											/>
-											<path
-												d="M180.73 129.5L210 151M153 108L173.027 123.357L153 108Z"
-												stroke="#FF458B"
-												stroke-width="2"
-												stroke-linecap="round"
-											/>
-											<path
-												d="M86.7375 77.1845L72 70M152 109L109.06 88.0667L152 109Z"
-												stroke="#FFC600"
-												stroke-width="2"
-												stroke-linecap="round"
-											/>
-											<path
-												d="M152.762 109.227L244.238 76.7727"
-												stroke="#00E567"
-												stroke-width="2"
-												stroke-linecap="round"
-											/>
-											<path
-												d="M154.5 104.5L111 131"
-												stroke="#00E567"
-												stroke-width="2"
-												stroke-linecap="round"
-											/>
-											<path
-												fill-rule="evenodd"
-												clip-rule="evenodd"
-												d="M224 57H238V71H224V57Z"
-												fill="#00E567"
-											/>
-											<path
-												fill-rule="evenodd"
-												clip-rule="evenodd"
-												d="M127 2H137V12H127V2Z"
-												fill="#FF458B"
-											/>
-											<path
-												fill-rule="evenodd"
-												clip-rule="evenodd"
-												d="M150 166H156V172H150V166Z"
-												fill="#FF458B"
-											/>
-											<path
-												fill-rule="evenodd"
-												clip-rule="evenodd"
-												d="M44 0H50V6H44V0Z"
-												fill="#00E567"
-											/>
-											<path
-												fill-rule="evenodd"
-												clip-rule="evenodd"
-												d="M294 111H300V117H294V111Z"
-												fill="#276CFF"
-											/>
-											<path
-												fill-rule="evenodd"
-												clip-rule="evenodd"
-												d="M0 121H6V127H0V121Z"
-												fill="#276CFF"
-											/>
-											<path
-												fill-rule="evenodd"
-												clip-rule="evenodd"
-												d="M268 86H274V92H268V86Z"
-												fill="#FFC600"
-											/>
-											<path
-												fill-rule="evenodd"
-												clip-rule="evenodd"
-												d="M28 91H46V109H28V91Z"
-												fill="#FFC600"
-											/>
-											<path
-												fill-rule="evenodd"
-												clip-rule="evenodd"
-												d="M181 21H203V43H181V21Z"
-												fill="#276CFF"
-											/>
-											<path
-												fill-rule="evenodd"
-												clip-rule="evenodd"
-												d="M154.958 55L179 79.0416V136H122V55H154.958Z"
-												fill="#0218A7"
-											/>
-											<path
-												d="M146.5 80H136.5C135.119 80 134 81.1193 134 82.5C134 83.8807 135.119 85 136.5 85H146.5C147.881 85 149 83.8807 149 82.5C149 81.1193 147.881 80 146.5 80Z"
-												fill="white"
-											/>
-											<path
-												d="M164.5 92H136.5C135.119 92 134 93.1193 134 94.5C134 95.8807 135.119 97 136.5 97H164.5C165.881 97 167 95.8807 167 94.5C167 93.1193 165.881 92 164.5 92Z"
-												fill="white"
-											/>
-											<path
-												d="M164.5 104H136.5C135.119 104 134 105.119 134 106.5C134 107.881 135.119 109 136.5 109H164.5C165.881 109 167 107.881 167 106.5C167 105.119 165.881 104 164.5 104Z"
-												fill="white"
-											/>
-											<path
-												d="M164.5 116H136.5C135.119 116 134 117.119 134 118.5C134 119.881 135.119 121 136.5 121H164.5C165.881 121 167 119.881 167 118.5C167 117.119 165.881 116 164.5 116Z"
-												fill="white"
-											/>
-											<path
-												fill-rule="evenodd"
-												clip-rule="evenodd"
-												d="M154.958 79.0416V55L179 79.0416H154.958Z"
-												fill="#276CFF"
-											/>
-										</svg>
-									</div>
-								</div>
-								<div class="col-6 col-lg-4 pr-5">
-									<div class="text-right">
-										<svg
-											v-on:click="closeModal"
-											xmlns="http://www.w3.org/2000/svg"
-											width="2em"
-											height="2em"
-											fill="#6e6e6e"
-											class="bi bi-x mt-4 closex"
-											viewBox="0 0 16 16"
-										>
-											<path
-												d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"
-											/>
-										</svg>
-									</div>
+									<video
+										class="preview"
+										controls
+										v-if="previewIsVideo"
+										v-bind:src="preSignedUrl"
+									></video>
 
-									<div class="mb-3">
-										<span class="file-path">{{
-											filePath
-										}}</span>
-									</div>
+									<audio
+										class="preview"
+										controls
+										v-if="previewIsAudio"
+										v-bind:src="preSignedUrl"
+									></audio>
 
-									<p class="size mb-3">
-										<span class="text-lighter mr-2"
-											>Size:</span
-										>
-										{{ size }}
-									</p>
-									<p class="size mb-3">
-										<span class="text-lighter mr-2"
-											>Created:</span
-										>
-										{{ uploadDate }}
-									</p>
-
-									<button
-										class="
-											btn btn-primary btn-block
-											mb-3
-											mt-4
-										"
-										download
-										v-on:click="download"
-									>
-										Download
-										<svg
-											width="14"
-											height="15"
-											viewBox="0 0 14 15"
-											alt="Download"
-											class="ml-2"
-											fill="none"
-											xmlns="http://www.w3.org/2000/svg"
-										>
-											<path
-												d="M6.0498 7.98517V0H8.0498V7.91442L10.4965 5.46774L11.9107 6.88196L7.01443 11.7782L2.11816 6.88196L3.53238 5.46774L6.0498 7.98517Z"
-												fill="white"
-											/>
-											<path
-												d="M0 13L14 13V15L0 15V13Z"
-												fill="white"
-											/>
-										</svg>
-									</button>
-
-									<div
-										v-if="objectLink"
-										class="input-group mt-4"
-									>
-										<input
-											class="form-control form-control-lg"
-											type="url"
-											id="url"
-											v-bind:value="objectLink"
-											aria-describedby="generateShareLink"
-											readonly
-										/>
-										<button
-											v-on:click="copy"
-											id="generateShareLink"
-											type="button"
-											name="copy"
-											class="
-												btn btn-outline-primary btn-copy
-											"
-										>
-											{{ copyText }}
-										</button>
-									</div>
-
-									<button
+									<svg
 										v-else
-										class="btn btn-light btn-block"
-										v-on:click="getSharedLink"
+										width="300"
+										height="172"
+										viewBox="0 0 300 172"
+										fill="none"
+										xmlns="http://www.w3.org/2000/svg"
+										class="preview-placeholder img-fluid px-5 pb-5"
 									>
-										<span class="share-btn">
-											Share
-											<svg
-												width="16"
-												height="16"
-												viewBox="0 0 16 16"
-												alt="Share"
-												class="ml-2"
-												fill="none"
-												xmlns="http://www.w3.org/2000/svg"
-											>
-												<path
-													d="M8.86084 11.7782L8.86084 3.79305L11.3783 6.31048L12.7925 4.89626L7.89622 0L2.99995 4.89626L4.41417 6.31048L6.86084 3.8638L6.86084 11.7782L8.86084 11.7782Z"
-													fill="#384B65"
-												/>
-												<path
-													d="M4.5 8.12502H0.125V15.875H15.875V8.12502H11.5V9.87502H14.125V14.125H1.875V9.87502H4.5V8.12502Z"
-													fill="#384B65"
-												/>
-											</svg>
-										</span>
-									</button>
-
-									<div
-										v-if="objectMapIsLoading"
-										class="
-											d-flex
-											justify-content-center
-											text-primary
-											mt-4
-										"
-									>
-										<div
-											class="spinner-border mt-3"
-											role="status"
-										></div>
-									</div>
-
-									<div class="mt-5" v-if="objectMapUrlExists">
-										<div class="storage-nodes">
-											Nodes storing this file
-										</div>
-										<img
-											class="object-map"
-											v-bind:src="objectMapUrl"
+										<path
+											d="M188.5 140C218.047 140 242 116.047 242 86.5C242 56.9528 218.047 33 188.5 33C158.953 33 135 56.9528 135 86.5C135 116.047 158.953 140 188.5 140Z"
+											fill="white"
 										/>
-									</div>
+										<path
+											d="M123.5 167C147.524 167 167 147.524 167 123.5C167 99.4756 147.524 80 123.5 80C99.4756 80 80 99.4756 80 123.5C80 147.524 99.4756 167 123.5 167Z"
+											fill="white"
+										/>
+										<path
+											d="M71.5 49C78.9558 49 85 42.9558 85 35.5C85 28.0442 78.9558 22 71.5 22C64.0442 22 58 28.0442 58 35.5C58 42.9558 64.0442 49 71.5 49Z"
+											fill="white"
+										/>
+										<path
+											d="M262.5 143C268.851 143 274 137.851 274 131.5C274 125.149 268.851 120 262.5 120C256.149 120 251 125.149 251 131.5C251 137.851 256.149 143 262.5 143Z"
+											fill="white"
+										/>
+										<path
+											d="M185.638 64.338L191 57M153 109L179.458 72.7948L153 109Z"
+											stroke="#276CFF"
+											stroke-width="2"
+											stroke-linecap="round"
+										/>
+										<path
+											d="M121.08 153.429L115 161M153 108L127.16 144.343L153 108Z"
+											stroke="#276CFF"
+											stroke-width="2"
+											stroke-linecap="round"
+										/>
+										<path
+											d="M134 71L115 31M152 109L139 81L152 109Z"
+											stroke="#FF458B"
+											stroke-width="2"
+											stroke-linecap="round"
+										/>
+										<path
+											d="M180.73 129.5L210 151M153 108L173.027 123.357L153 108Z"
+											stroke="#FF458B"
+											stroke-width="2"
+											stroke-linecap="round"
+										/>
+										<path
+											d="M86.7375 77.1845L72 70M152 109L109.06 88.0667L152 109Z"
+											stroke="#FFC600"
+											stroke-width="2"
+											stroke-linecap="round"
+										/>
+										<path
+											d="M152.762 109.227L244.238 76.7727"
+											stroke="#00E567"
+											stroke-width="2"
+											stroke-linecap="round"
+										/>
+										<path
+											d="M154.5 104.5L111 131"
+											stroke="#00E567"
+											stroke-width="2"
+											stroke-linecap="round"
+										/>
+										<path
+											fill-rule="evenodd"
+											clip-rule="evenodd"
+											d="M224 57H238V71H224V57Z"
+											fill="#00E567"
+										/>
+										<path
+											fill-rule="evenodd"
+											clip-rule="evenodd"
+											d="M127 2H137V12H127V2Z"
+											fill="#FF458B"
+										/>
+										<path
+											fill-rule="evenodd"
+											clip-rule="evenodd"
+											d="M150 166H156V172H150V166Z"
+											fill="#FF458B"
+										/>
+										<path
+											fill-rule="evenodd"
+											clip-rule="evenodd"
+											d="M44 0H50V6H44V0Z"
+											fill="#00E567"
+										/>
+										<path
+											fill-rule="evenodd"
+											clip-rule="evenodd"
+											d="M294 111H300V117H294V111Z"
+											fill="#276CFF"
+										/>
+										<path
+											fill-rule="evenodd"
+											clip-rule="evenodd"
+											d="M0 121H6V127H0V121Z"
+											fill="#276CFF"
+										/>
+										<path
+											fill-rule="evenodd"
+											clip-rule="evenodd"
+											d="M268 86H274V92H268V86Z"
+											fill="#FFC600"
+										/>
+										<path
+											fill-rule="evenodd"
+											clip-rule="evenodd"
+											d="M28 91H46V109H28V91Z"
+											fill="#FFC600"
+										/>
+										<path
+											fill-rule="evenodd"
+											clip-rule="evenodd"
+											d="M181 21H203V43H181V21Z"
+											fill="#276CFF"
+										/>
+										<path
+											fill-rule="evenodd"
+											clip-rule="evenodd"
+											d="M154.958 55L179 79.0416V136H122V55H154.958Z"
+											fill="#0218A7"
+										/>
+										<path
+											d="M146.5 80H136.5C135.119 80 134 81.1193 134 82.5C134 83.8807 135.119 85 136.5 85H146.5C147.881 85 149 83.8807 149 82.5C149 81.1193 147.881 80 146.5 80Z"
+											fill="white"
+										/>
+										<path
+											d="M164.5 92H136.5C135.119 92 134 93.1193 134 94.5C134 95.8807 135.119 97 136.5 97H164.5C165.881 97 167 95.8807 167 94.5C167 93.1193 165.881 92 164.5 92Z"
+											fill="white"
+										/>
+										<path
+											d="M164.5 104H136.5C135.119 104 134 105.119 134 106.5C134 107.881 135.119 109 136.5 109H164.5C165.881 109 167 107.881 167 106.5C167 105.119 165.881 104 164.5 104Z"
+											fill="white"
+										/>
+										<path
+											d="M164.5 116H136.5C135.119 116 134 117.119 134 118.5C134 119.881 135.119 121 136.5 121H164.5C165.881 121 167 119.881 167 118.5C167 117.119 165.881 116 164.5 116Z"
+											fill="white"
+										/>
+										<path
+											fill-rule="evenodd"
+											clip-rule="evenodd"
+											d="M154.958 79.0416V55L179 79.0416H154.958Z"
+											fill="#276CFF"
+										/>
+									</svg>
+
 								</div>
 							</div>
+							<div class="col-6 col-lg-4 pr-5">
+
+						<div class="text-right">
+							<svg
+								v-on:click="closeModal"
+								xmlns="http://www.w3.org/2000/svg"
+								width="2em"
+								height="2em"
+								fill="#6e6e6e"
+								class="bi bi-x mt-4 closex"
+								viewBox="0 0 16 16"
+							>
+								<path
+									d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"
+								/>
+							</svg>
 						</div>
+
+						<div class="mb-3">
+							<span class="file-path">{{ filePath }}</span>
+						</div>
+
+						<p class="size mb-3"><span class="text-lighter mr-2">Size:</span> {{ size }}</p>
+						<p class="size mb-3"><span class="text-lighter mr-2">Created:</span> {{ uploadDate }}</p>
+
+						<button
+							class="btn btn-primary btn-block mb-3 mt-4"
+							download
+							v-on:click="download"
+						>
+							Download
+							<svg width="14" height="15" viewBox="0 0 14 15" alt="Download" class="ml-2" fill="none" xmlns="http://www.w3.org/2000/svg">
+								<path d="M6.0498 7.98517V0H8.0498V7.91442L10.4965 5.46774L11.9107 6.88196L7.01443 11.7782L2.11816 6.88196L3.53238 5.46774L6.0498 7.98517Z" fill="white"/>
+								<path d="M0 13L14 13V15L0 15V13Z" fill="white"/>
+							</svg>
+						</button>
+
+						<div v-if="objectLink" class="input-group mt-4">
+							<input
+								class="form-control"
+								type="url"
+								id="url"
+								v-bind:value="objectLink"
+								aria-describedby="generateShareLink"
+								readonly
+							/>
+							<div class="input-group-append">
+								<button
+									v-on:click="copy"
+									type="button"
+									name="copy"
+									class="btn btn-outline-secondary btn-copy-link"
+									id="generateShareLink"
+								>
+									{{ this.copyText }}
+								</button>
+							</div>
+						</div>
+
+						<button
+							v-else
+							class="btn btn-light btn-block"
+							v-on:click="getSharedLink"
+						>
+							<span class="share-btn">
+								Share
+								<svg width="16" height="16" viewBox="0 0 16 16" alt="Share" class="ml-2" fill="none" xmlns="http://www.w3.org/2000/svg">
+									<path d="M8.86084 11.7782L8.86084 3.79305L11.3783 6.31048L12.7925 4.89626L7.89622 0L2.99995 4.89626L4.41417 6.31048L6.86084 3.8638L6.86084 11.7782L8.86084 11.7782Z" fill="#384B65"/>
+									<path d="M4.5 8.12502H0.125V15.875H15.875V8.12502H11.5V9.87502H14.125V14.125H1.875V9.87502H4.5V8.12502Z" fill="#384B65"/>
+								</svg>
+							</span>
+						</button>
+
+						<div
+							v-if="objectMapIsLoading"
+							class="d-flex justify-content-center text-primary mt-4"
+						>
+							<div
+								class="spinner-border mt-3"
+								role="status"
+							></div>
+						</div>
+
+					<div class="mt-5" v-if="objectMapUrl !== null">
+						<div class="storage-nodes">Nodes storing this file</div>
+						<img class="object-map" v-bind:src="objectMapUrl" />
 					</div>
+
 				</div>
 			</div>
 		</div>
-		<div class="modal-backdrop fade show modal-open" id="backdrop2"></div>
+
+				</div>
+			</div>
+		</div>
 	</div>
+	<div class="modal-backdrop fade show modal-open" id="backdrop2"></div>
+
+</div>
 </template>
 
 <script>

--- a/src/components/FileModal.vue
+++ b/src/components/FileModal.vue
@@ -102,287 +102,358 @@
 			role="dialog"
 			aria-labelledby="modalLabel"
 		>
-			<div class="modal-dialog modal-xl modal-dialog-centered" role="document">
+			<div
+				class="modal-dialog modal-xl modal-dialog-centered"
+				role="document"
+			>
 				<div class="modal-content">
 					<div class="modal-body p-0">
 						<div class="container-fluid p-0">
-
-						<div class="row">
-							<div class="col-6 col-lg-8">
-								<div class="file-preview-wrapper d-flex align-items-center">
-
-									<img
-										class="preview img-fluid"
-										v-if="previewIsImage"
-										v-bind:src="preSignedUrl"
-									/>
-
-									<video
-										class="preview"
-										controls
-										v-if="previewIsVideo"
-										v-bind:src="preSignedUrl"
-									></video>
-
-									<audio
-										class="preview"
-										controls
-										v-if="previewIsAudio"
-										v-bind:src="preSignedUrl"
-									></audio>
-
-									<svg
-										v-else
-										width="300"
-										height="172"
-										viewBox="0 0 300 172"
-										fill="none"
-										xmlns="http://www.w3.org/2000/svg"
-										class="preview-placeholder img-fluid px-5 pb-5"
+							<div class="row">
+								<div class="col-6 col-lg-8">
+									<div
+										class="
+											file-preview-wrapper
+											d-flex
+											align-items-center
+										"
 									>
-										<path
-											d="M188.5 140C218.047 140 242 116.047 242 86.5C242 56.9528 218.047 33 188.5 33C158.953 33 135 56.9528 135 86.5C135 116.047 158.953 140 188.5 140Z"
-											fill="white"
+										<img
+											class="preview img-fluid"
+											v-if="previewIsImage"
+											v-bind:src="preSignedUrl"
 										/>
-										<path
-											d="M123.5 167C147.524 167 167 147.524 167 123.5C167 99.4756 147.524 80 123.5 80C99.4756 80 80 99.4756 80 123.5C80 147.524 99.4756 167 123.5 167Z"
-											fill="white"
-										/>
-										<path
-											d="M71.5 49C78.9558 49 85 42.9558 85 35.5C85 28.0442 78.9558 22 71.5 22C64.0442 22 58 28.0442 58 35.5C58 42.9558 64.0442 49 71.5 49Z"
-											fill="white"
-										/>
-										<path
-											d="M262.5 143C268.851 143 274 137.851 274 131.5C274 125.149 268.851 120 262.5 120C256.149 120 251 125.149 251 131.5C251 137.851 256.149 143 262.5 143Z"
-											fill="white"
-										/>
-										<path
-											d="M185.638 64.338L191 57M153 109L179.458 72.7948L153 109Z"
-											stroke="#276CFF"
-											stroke-width="2"
-											stroke-linecap="round"
-										/>
-										<path
-											d="M121.08 153.429L115 161M153 108L127.16 144.343L153 108Z"
-											stroke="#276CFF"
-											stroke-width="2"
-											stroke-linecap="round"
-										/>
-										<path
-											d="M134 71L115 31M152 109L139 81L152 109Z"
-											stroke="#FF458B"
-											stroke-width="2"
-											stroke-linecap="round"
-										/>
-										<path
-											d="M180.73 129.5L210 151M153 108L173.027 123.357L153 108Z"
-											stroke="#FF458B"
-											stroke-width="2"
-											stroke-linecap="round"
-										/>
-										<path
-											d="M86.7375 77.1845L72 70M152 109L109.06 88.0667L152 109Z"
-											stroke="#FFC600"
-											stroke-width="2"
-											stroke-linecap="round"
-										/>
-										<path
-											d="M152.762 109.227L244.238 76.7727"
-											stroke="#00E567"
-											stroke-width="2"
-											stroke-linecap="round"
-										/>
-										<path
-											d="M154.5 104.5L111 131"
-											stroke="#00E567"
-											stroke-width="2"
-											stroke-linecap="round"
-										/>
-										<path
-											fill-rule="evenodd"
-											clip-rule="evenodd"
-											d="M224 57H238V71H224V57Z"
-											fill="#00E567"
-										/>
-										<path
-											fill-rule="evenodd"
-											clip-rule="evenodd"
-											d="M127 2H137V12H127V2Z"
-											fill="#FF458B"
-										/>
-										<path
-											fill-rule="evenodd"
-											clip-rule="evenodd"
-											d="M150 166H156V172H150V166Z"
-											fill="#FF458B"
-										/>
-										<path
-											fill-rule="evenodd"
-											clip-rule="evenodd"
-											d="M44 0H50V6H44V0Z"
-											fill="#00E567"
-										/>
-										<path
-											fill-rule="evenodd"
-											clip-rule="evenodd"
-											d="M294 111H300V117H294V111Z"
-											fill="#276CFF"
-										/>
-										<path
-											fill-rule="evenodd"
-											clip-rule="evenodd"
-											d="M0 121H6V127H0V121Z"
-											fill="#276CFF"
-										/>
-										<path
-											fill-rule="evenodd"
-											clip-rule="evenodd"
-											d="M268 86H274V92H268V86Z"
-											fill="#FFC600"
-										/>
-										<path
-											fill-rule="evenodd"
-											clip-rule="evenodd"
-											d="M28 91H46V109H28V91Z"
-											fill="#FFC600"
-										/>
-										<path
-											fill-rule="evenodd"
-											clip-rule="evenodd"
-											d="M181 21H203V43H181V21Z"
-											fill="#276CFF"
-										/>
-										<path
-											fill-rule="evenodd"
-											clip-rule="evenodd"
-											d="M154.958 55L179 79.0416V136H122V55H154.958Z"
-											fill="#0218A7"
-										/>
-										<path
-											d="M146.5 80H136.5C135.119 80 134 81.1193 134 82.5C134 83.8807 135.119 85 136.5 85H146.5C147.881 85 149 83.8807 149 82.5C149 81.1193 147.881 80 146.5 80Z"
-											fill="white"
-										/>
-										<path
-											d="M164.5 92H136.5C135.119 92 134 93.1193 134 94.5C134 95.8807 135.119 97 136.5 97H164.5C165.881 97 167 95.8807 167 94.5C167 93.1193 165.881 92 164.5 92Z"
-											fill="white"
-										/>
-										<path
-											d="M164.5 104H136.5C135.119 104 134 105.119 134 106.5C134 107.881 135.119 109 136.5 109H164.5C165.881 109 167 107.881 167 106.5C167 105.119 165.881 104 164.5 104Z"
-											fill="white"
-										/>
-										<path
-											d="M164.5 116H136.5C135.119 116 134 117.119 134 118.5C134 119.881 135.119 121 136.5 121H164.5C165.881 121 167 119.881 167 118.5C167 117.119 165.881 116 164.5 116Z"
-											fill="white"
-										/>
-										<path
-											fill-rule="evenodd"
-											clip-rule="evenodd"
-											d="M154.958 79.0416V55L179 79.0416H154.958Z"
-											fill="#276CFF"
-										/>
-									</svg>
 
+										<video
+											class="preview"
+											controls
+											v-if="previewIsVideo"
+											v-bind:src="preSignedUrl"
+										></video>
+
+										<audio
+											class="preview"
+											controls
+											v-if="previewIsAudio"
+											v-bind:src="preSignedUrl"
+										></audio>
+
+										<svg
+											v-else
+											width="300"
+											height="172"
+											viewBox="0 0 300 172"
+											fill="none"
+											xmlns="http://www.w3.org/2000/svg"
+											class="
+												preview-placeholder
+												img-fluid
+												px-5
+												pb-5
+											"
+										>
+											<path
+												d="M188.5 140C218.047 140 242 116.047 242 86.5C242 56.9528 218.047 33 188.5 33C158.953 33 135 56.9528 135 86.5C135 116.047 158.953 140 188.5 140Z"
+												fill="white"
+											/>
+											<path
+												d="M123.5 167C147.524 167 167 147.524 167 123.5C167 99.4756 147.524 80 123.5 80C99.4756 80 80 99.4756 80 123.5C80 147.524 99.4756 167 123.5 167Z"
+												fill="white"
+											/>
+											<path
+												d="M71.5 49C78.9558 49 85 42.9558 85 35.5C85 28.0442 78.9558 22 71.5 22C64.0442 22 58 28.0442 58 35.5C58 42.9558 64.0442 49 71.5 49Z"
+												fill="white"
+											/>
+											<path
+												d="M262.5 143C268.851 143 274 137.851 274 131.5C274 125.149 268.851 120 262.5 120C256.149 120 251 125.149 251 131.5C251 137.851 256.149 143 262.5 143Z"
+												fill="white"
+											/>
+											<path
+												d="M185.638 64.338L191 57M153 109L179.458 72.7948L153 109Z"
+												stroke="#276CFF"
+												stroke-width="2"
+												stroke-linecap="round"
+											/>
+											<path
+												d="M121.08 153.429L115 161M153 108L127.16 144.343L153 108Z"
+												stroke="#276CFF"
+												stroke-width="2"
+												stroke-linecap="round"
+											/>
+											<path
+												d="M134 71L115 31M152 109L139 81L152 109Z"
+												stroke="#FF458B"
+												stroke-width="2"
+												stroke-linecap="round"
+											/>
+											<path
+												d="M180.73 129.5L210 151M153 108L173.027 123.357L153 108Z"
+												stroke="#FF458B"
+												stroke-width="2"
+												stroke-linecap="round"
+											/>
+											<path
+												d="M86.7375 77.1845L72 70M152 109L109.06 88.0667L152 109Z"
+												stroke="#FFC600"
+												stroke-width="2"
+												stroke-linecap="round"
+											/>
+											<path
+												d="M152.762 109.227L244.238 76.7727"
+												stroke="#00E567"
+												stroke-width="2"
+												stroke-linecap="round"
+											/>
+											<path
+												d="M154.5 104.5L111 131"
+												stroke="#00E567"
+												stroke-width="2"
+												stroke-linecap="round"
+											/>
+											<path
+												fill-rule="evenodd"
+												clip-rule="evenodd"
+												d="M224 57H238V71H224V57Z"
+												fill="#00E567"
+											/>
+											<path
+												fill-rule="evenodd"
+												clip-rule="evenodd"
+												d="M127 2H137V12H127V2Z"
+												fill="#FF458B"
+											/>
+											<path
+												fill-rule="evenodd"
+												clip-rule="evenodd"
+												d="M150 166H156V172H150V166Z"
+												fill="#FF458B"
+											/>
+											<path
+												fill-rule="evenodd"
+												clip-rule="evenodd"
+												d="M44 0H50V6H44V0Z"
+												fill="#00E567"
+											/>
+											<path
+												fill-rule="evenodd"
+												clip-rule="evenodd"
+												d="M294 111H300V117H294V111Z"
+												fill="#276CFF"
+											/>
+											<path
+												fill-rule="evenodd"
+												clip-rule="evenodd"
+												d="M0 121H6V127H0V121Z"
+												fill="#276CFF"
+											/>
+											<path
+												fill-rule="evenodd"
+												clip-rule="evenodd"
+												d="M268 86H274V92H268V86Z"
+												fill="#FFC600"
+											/>
+											<path
+												fill-rule="evenodd"
+												clip-rule="evenodd"
+												d="M28 91H46V109H28V91Z"
+												fill="#FFC600"
+											/>
+											<path
+												fill-rule="evenodd"
+												clip-rule="evenodd"
+												d="M181 21H203V43H181V21Z"
+												fill="#276CFF"
+											/>
+											<path
+												fill-rule="evenodd"
+												clip-rule="evenodd"
+												d="M154.958 55L179 79.0416V136H122V55H154.958Z"
+												fill="#0218A7"
+											/>
+											<path
+												d="M146.5 80H136.5C135.119 80 134 81.1193 134 82.5C134 83.8807 135.119 85 136.5 85H146.5C147.881 85 149 83.8807 149 82.5C149 81.1193 147.881 80 146.5 80Z"
+												fill="white"
+											/>
+											<path
+												d="M164.5 92H136.5C135.119 92 134 93.1193 134 94.5C134 95.8807 135.119 97 136.5 97H164.5C165.881 97 167 95.8807 167 94.5C167 93.1193 165.881 92 164.5 92Z"
+												fill="white"
+											/>
+											<path
+												d="M164.5 104H136.5C135.119 104 134 105.119 134 106.5C134 107.881 135.119 109 136.5 109H164.5C165.881 109 167 107.881 167 106.5C167 105.119 165.881 104 164.5 104Z"
+												fill="white"
+											/>
+											<path
+												d="M164.5 116H136.5C135.119 116 134 117.119 134 118.5C134 119.881 135.119 121 136.5 121H164.5C165.881 121 167 119.881 167 118.5C167 117.119 165.881 116 164.5 116Z"
+												fill="white"
+											/>
+											<path
+												fill-rule="evenodd"
+												clip-rule="evenodd"
+												d="M154.958 79.0416V55L179 79.0416H154.958Z"
+												fill="#276CFF"
+											/>
+										</svg>
+									</div>
+								</div>
+								<div class="col-6 col-lg-4 pr-5">
+									<div class="text-right">
+										<svg
+											v-on:click="closeModal"
+											xmlns="http://www.w3.org/2000/svg"
+											width="2em"
+											height="2em"
+											fill="#6e6e6e"
+											class="bi bi-x mt-4 closex"
+											viewBox="0 0 16 16"
+										>
+											<path
+												d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"
+											/>
+										</svg>
+									</div>
+
+									<div class="mb-3">
+										<span class="file-path">{{
+											filePath
+										}}</span>
+									</div>
+
+									<p class="size mb-3">
+										<span class="text-lighter mr-2"
+											>Size:</span
+										>
+										{{ size }}
+									</p>
+									<p class="size mb-3">
+										<span class="text-lighter mr-2"
+											>Created:</span
+										>
+										{{ uploadDate }}
+									</p>
+
+									<button
+										class="
+											btn btn-primary btn-block
+											mb-3
+											mt-4
+										"
+										download
+										v-on:click="download"
+									>
+										Download
+										<svg
+											width="14"
+											height="15"
+											viewBox="0 0 14 15"
+											alt="Download"
+											class="ml-2"
+											fill="none"
+											xmlns="http://www.w3.org/2000/svg"
+										>
+											<path
+												d="M6.0498 7.98517V0H8.0498V7.91442L10.4965 5.46774L11.9107 6.88196L7.01443 11.7782L2.11816 6.88196L3.53238 5.46774L6.0498 7.98517Z"
+												fill="white"
+											/>
+											<path
+												d="M0 13L14 13V15L0 15V13Z"
+												fill="white"
+											/>
+										</svg>
+									</button>
+
+									<div
+										v-if="objectLink"
+										class="input-group mt-4"
+									>
+										<input
+											class="form-control"
+											type="url"
+											id="url"
+											v-bind:value="objectLink"
+											aria-describedby="generateShareLink"
+											readonly
+										/>
+										<div class="input-group-append">
+											<button
+												v-on:click="copy"
+												type="button"
+												name="copy"
+												class="
+													btn
+													btn-outline-secondary
+													btn-copy-link
+												"
+												id="generateShareLink"
+											>
+												{{ this.copyText }}
+											</button>
+										</div>
+									</div>
+
+									<button
+										v-else
+										class="btn btn-light btn-block"
+										v-on:click="getSharedLink"
+									>
+										<span class="share-btn">
+											Share
+											<svg
+												width="16"
+												height="16"
+												viewBox="0 0 16 16"
+												alt="Share"
+												class="ml-2"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M8.86084 11.7782L8.86084 3.79305L11.3783 6.31048L12.7925 4.89626L7.89622 0L2.99995 4.89626L4.41417 6.31048L6.86084 3.8638L6.86084 11.7782L8.86084 11.7782Z"
+													fill="#384B65"
+												/>
+												<path
+													d="M4.5 8.12502H0.125V15.875H15.875V8.12502H11.5V9.87502H14.125V14.125H1.875V9.87502H4.5V8.12502Z"
+													fill="#384B65"
+												/>
+											</svg>
+										</span>
+									</button>
+
+									<div
+										v-if="objectMapIsLoading"
+										class="
+											d-flex
+											justify-content-center
+											text-primary
+											mt-4
+										"
+									>
+										<div
+											class="spinner-border mt-3"
+											role="status"
+										></div>
+									</div>
+
+									<div
+										class="mt-5"
+										v-if="objectMapUrl !== null"
+									>
+										<div class="storage-nodes">
+											Nodes storing this file
+										</div>
+										<img
+											class="object-map"
+											v-bind:src="objectMapUrl"
+										/>
+									</div>
 								</div>
 							</div>
-							<div class="col-6 col-lg-4 pr-5">
-
-						<div class="text-right">
-							<svg
-								v-on:click="closeModal"
-								xmlns="http://www.w3.org/2000/svg"
-								width="2em"
-								height="2em"
-								fill="#6e6e6e"
-								class="bi bi-x mt-4 closex"
-								viewBox="0 0 16 16"
-							>
-								<path
-									d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"
-								/>
-							</svg>
 						</div>
-
-						<div class="mb-3">
-							<span class="file-path">{{ filePath }}</span>
-						</div>
-
-						<p class="size mb-3"><span class="text-lighter mr-2">Size:</span> {{ size }}</p>
-						<p class="size mb-3"><span class="text-lighter mr-2">Created:</span> {{ uploadDate }}</p>
-
-						<button
-							class="btn btn-primary btn-block mb-3 mt-4"
-							download
-							v-on:click="download"
-						>
-							Download
-							<svg width="14" height="15" viewBox="0 0 14 15" alt="Download" class="ml-2" fill="none" xmlns="http://www.w3.org/2000/svg">
-								<path d="M6.0498 7.98517V0H8.0498V7.91442L10.4965 5.46774L11.9107 6.88196L7.01443 11.7782L2.11816 6.88196L3.53238 5.46774L6.0498 7.98517Z" fill="white"/>
-								<path d="M0 13L14 13V15L0 15V13Z" fill="white"/>
-							</svg>
-						</button>
-
-						<div v-if="objectLink" class="input-group mt-4">
-							<input
-								class="form-control"
-								type="url"
-								id="url"
-								v-bind:value="objectLink"
-								aria-describedby="generateShareLink"
-								readonly
-							/>
-							<div class="input-group-append">
-								<button
-									v-on:click="copy"
-									type="button"
-									name="copy"
-									class="btn btn-outline-secondary btn-copy-link"
-									id="generateShareLink"
-								>
-									{{ this.copyText }}
-								</button>
-							</div>
-						</div>
-
-						<button
-							v-else
-							class="btn btn-light btn-block"
-							v-on:click="getSharedLink"
-						>
-							<span class="share-btn">
-								Share
-								<svg width="16" height="16" viewBox="0 0 16 16" alt="Share" class="ml-2" fill="none" xmlns="http://www.w3.org/2000/svg">
-									<path d="M8.86084 11.7782L8.86084 3.79305L11.3783 6.31048L12.7925 4.89626L7.89622 0L2.99995 4.89626L4.41417 6.31048L6.86084 3.8638L6.86084 11.7782L8.86084 11.7782Z" fill="#384B65"/>
-									<path d="M4.5 8.12502H0.125V15.875H15.875V8.12502H11.5V9.87502H14.125V14.125H1.875V9.87502H4.5V8.12502Z" fill="#384B65"/>
-								</svg>
-							</span>
-						</button>
-
-						<div
-							v-if="objectMapIsLoading"
-							class="d-flex justify-content-center text-primary mt-4"
-						>
-							<div
-								class="spinner-border mt-3"
-								role="status"
-							></div>
-						</div>
-
-					<div class="mt-5" v-if="objectMapUrl !== null">
-						<div class="storage-nodes">Nodes storing this file</div>
-						<img class="object-map" v-bind:src="objectMapUrl" />
 					</div>
-
 				</div>
 			</div>
 		</div>
-
-				</div>
-			</div>
-		</div>
+		<div class="modal-backdrop fade show modal-open" id="backdrop2"></div>
 	</div>
-	<div class="modal-backdrop fade show modal-open" id="backdrop2"></div>
-
-</div>
 </template>
 
 <script>

--- a/src/components/FileShareModal.vue
+++ b/src/components/FileShareModal.vue
@@ -31,187 +31,188 @@
 
 .resp-sharing-button__link,
 .resp-sharing-button__icon {
-  display: inline-block;
+	display: inline-block;
 }
 
 .resp-sharing-button__link {
-  text-decoration: none;
-  color: #fff;
+	text-decoration: none;
+	color: #fff;
 	margin-right: 1em;
-  margin-bottom: 1em;
+	margin-bottom: 1em;
 }
 
 .resp-sharing-button {
-  border-radius: 5px;
-  transition: 25ms ease-out;
-  padding: 0.5em 0.75em;
+	border-radius: 5px;
+	transition: 25ms ease-out;
+	padding: 0.5em 0.75em;
 	font-size: 12px;
 }
 
 .resp-sharing-button__icon svg {
-  width: 1em;
-  height: 1em;
-  margin-right: 0.4em;
-  vertical-align: middle;
+	width: 1em;
+	height: 1em;
+	margin-right: 0.4em;
+	vertical-align: middle;
 }
 
 .resp-sharing-button--small svg {
-  margin: 0;
-  vertical-align: middle;
+	margin: 0;
+	vertical-align: middle;
 }
 
 .resp-sharing-button__icon--solid,
 .resp-sharing-button__icon--solidcircle {
-  fill: #fff;
-  stroke: none;
+	fill: #fff;
+	stroke: none;
 }
 
 .resp-sharing-button--twitter {
-  background-color: #55acee;
+	background-color: #55acee;
 }
 
 .resp-sharing-button--twitter:hover {
-  background-color: #2795e9;
+	background-color: #2795e9;
 }
 
 .resp-sharing-button--facebook {
-  background-color: #3b5998;
+	background-color: #3b5998;
 }
 
 .resp-sharing-button--facebook:hover {
-  background-color: #2d4373;
+	background-color: #2d4373;
 }
 
 .resp-sharing-button--reddit {
-  background-color: #5f99cf;
+	background-color: #5f99cf;
 }
 
 .resp-sharing-button--reddit:hover {
-  background-color: #3a80c1;
+	background-color: #3a80c1;
 }
 
 .resp-sharing-button--linkedin {
-  background-color: #0077b5;
+	background-color: #0077b5;
 }
 
 .resp-sharing-button--linkedin:hover {
-  background-color: #046293;
+	background-color: #046293;
 }
 
 .resp-sharing-button--email {
-  background-color: #777
+	background-color: #777;
 }
 
 .resp-sharing-button--email:hover {
-  background-color: #5e5e5e;
+	background-color: #5e5e5e;
 }
 
 .resp-sharing-button--hackernews {
-	background-color: #FF6600;
+	background-color: #ff6600;
 }
-.resp-sharing-button--hackernews:hover, .resp-sharing-button--hackernews:focus {   background-color: #FB6200 }
+.resp-sharing-button--hackernews:hover,
+.resp-sharing-button--hackernews:focus {
+	background-color: #fb6200;
+}
 
 .resp-sharing-button--facebook {
-  background-color: #3b5998;
-  border-color: #3b5998;
+	background-color: #3b5998;
+	border-color: #3b5998;
 }
 
 .resp-sharing-button--facebook:hover,
 .resp-sharing-button--facebook:active {
-  background-color: #2d4373;
-  border-color: #2d4373;
+	background-color: #2d4373;
+	border-color: #2d4373;
 }
 
 .resp-sharing-button--twitter {
-  background-color: #55acee;
-  border-color: #55acee;
+	background-color: #55acee;
+	border-color: #55acee;
 }
 
 .resp-sharing-button--twitter:hover,
 .resp-sharing-button--twitter:active {
-  background-color: #2795e9;
-  border-color: #2795e9;
+	background-color: #2795e9;
+	border-color: #2795e9;
 }
 
 .resp-sharing-button--email {
-  background-color: #777777;
-  border-color: #777777;
+	background-color: #777777;
+	border-color: #777777;
 }
 
 .resp-sharing-button--email:hover,
 .resp-sharing-button--email:active {
-  background-color: #5e5e5e;
-  border-color: #5e5e5e;
+	background-color: #5e5e5e;
+	border-color: #5e5e5e;
 }
 
 .resp-sharing-button--reddit {
-  background-color: #5f99cf;
-  border-color: #5f99cf;
+	background-color: #5f99cf;
+	border-color: #5f99cf;
 }
 
 .resp-sharing-button--reddit:hover,
 .resp-sharing-button--reddit:active {
-  background-color: #3a80c1;
-  border-color: #3a80c1;
+	background-color: #3a80c1;
+	border-color: #3a80c1;
 }
 
 .resp-sharing-button--hackernews {
-  background-color: #FF6600;
-  border-color: #FF6600;
+	background-color: #ff6600;
+	border-color: #ff6600;
 }
 
-.resp-sharing-button--hackernews:hover
-.resp-sharing-button--hackernews:active {
-  background-color: #FB6200;
-  border-color: #FB6200;
+.resp-sharing-button--hackernews:hover .resp-sharing-button--hackernews:active {
+	background-color: #fb6200;
+	border-color: #fb6200;
 }
 
 .resp-sharing-button--whatsapp {
-  background-color: #25D366;
-  border-color: #25D366;
+	background-color: #25d366;
+	border-color: #25d366;
 }
 
 .resp-sharing-button--whatsapp:hover,
 .resp-sharing-button--whatsapp:active {
-  background-color: #1DA851;
-  border-color: #1DA851;
+	background-color: #1da851;
+	border-color: #1da851;
 }
 
 .resp-sharing-button--whatsapp {
-  background-color: #25D366
+	background-color: #25d366;
 }
 
 .resp-sharing-button--whatsapp:hover {
-  background-color: #1da851
+	background-color: #1da851;
 }
 
 .resp-sharing-button--linkedin {
-  background-color: #0077b5;
-  border-color: #0077b5;
+	background-color: #0077b5;
+	border-color: #0077b5;
 }
 
 .resp-sharing-button--linkedin:hover,
 .resp-sharing-button--linkedin:active {
-  background-color: #046293;
-  border-color: #046293;
+	background-color: #046293;
+	border-color: #046293;
 }
 
 .resp-sharing-button--linkedin {
-  background-color: #0077b5
+	background-color: #0077b5;
 }
 
 .resp-sharing-button--linkedin:hover {
-  background-color: #046293
+	background-color: #046293;
 }
 
 .resp-sharing-button--telegram {
-  background-color: #54A9EB;
+	background-color: #54a9eb;
 }
 
 .resp-sharing-button--telegram:hover {
-  background-color: #4B97D1;
+	background-color: #4b97d1;
 }
-
 </style>
 
 <template>
@@ -224,74 +225,335 @@
 			aria-hidden="true"
 		>
 			<div class="modal-dialog modal-dialog-centered">
-				<div
-					class="modal-content text-center border-0 p-2 p-sm-4"
-				>
+				<div class="modal-content text-center border-0 p-2 p-sm-4">
 					<div class="modal-header border-0">
 						<h5 class="modal-title pt-2">Share</h5>
-						<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+						<button
+							type="button"
+							class="close"
+							data-dismiss="modal"
+							aria-label="Close"
+						>
 							<span aria-hidden="true">&times;</span>
 						</button>
 					</div>
 					<div class="modal-body pt-0 text-left">
-
 						<div>
-
-							<hr>
+							<hr />
 							<div class="social-share-icons my-4">
-
 								<p>Share this link via</p>
 
 								<!-- Sharingbutton Reddit -->
-								<a class="resp-sharing-button__link" v-bind:href="'https://reddit.com/submit/?url='+ objectLink +'&amp;resubmit=true&amp;title=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage'" target="_blank" rel="noopener" aria-label="Reddit">
-									<div class="resp-sharing-button resp-sharing-button--reddit resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
-										<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M24 11.5c0-1.65-1.35-3-3-3-.96 0-1.86.48-2.42 1.24-1.64-1-3.75-1.64-6.07-1.72.08-1.1.4-3.05 1.52-3.7.72-.4 1.73-.24 3 .5C17.2 6.3 18.46 7.5 20 7.5c1.65 0 3-1.35 3-3s-1.35-3-3-3c-1.38 0-2.54.94-2.88 2.22-1.43-.72-2.64-.8-3.6-.25-1.64.94-1.95 3.47-2 4.55-2.33.08-4.45.7-6.1 1.72C4.86 8.98 3.96 8.5 3 8.5c-1.65 0-3 1.35-3 3 0 1.32.84 2.44 2.05 2.84-.03.22-.05.44-.05.66 0 3.86 4.5 7 10 7s10-3.14 10-7c0-.22-.02-.44-.05-.66 1.2-.4 2.05-1.54 2.05-2.84zM2.3 13.37C1.5 13.07 1 12.35 1 11.5c0-1.1.9-2 2-2 .64 0 1.22.32 1.6.82-1.1.85-1.92 1.9-2.3 3.05zm3.7.13c0-1.1.9-2 2-2s2 .9 2 2-.9 2-2 2-2-.9-2-2zm9.8 4.8c-1.08.63-2.42.96-3.8.96-1.4 0-2.74-.34-3.8-.95-.24-.13-.32-.44-.2-.68.15-.24.46-.32.7-.18 1.83 1.06 4.76 1.06 6.6 0 .23-.13.53-.05.67.2.14.23.06.54-.18.67zm.2-2.8c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm5.7-2.13c-.38-1.16-1.2-2.2-2.3-3.05.38-.5.97-.82 1.6-.82 1.1 0 2 .9 2 2 0 .84-.53 1.57-1.3 1.87z"/></svg></div>Reddit</div>
+								<a
+									class="resp-sharing-button__link"
+									v-bind:href="
+										'https://reddit.com/submit/?url=' +
+										objectLink +
+										'&amp;resubmit=true&amp;title=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage'
+									"
+									target="_blank"
+									rel="noopener"
+									aria-label="Reddit"
+								>
+									<div
+										class="
+											resp-sharing-button
+											resp-sharing-button--reddit
+											resp-sharing-button--medium
+										"
+									>
+										<div
+											aria-hidden="true"
+											class="
+												resp-sharing-button__icon
+												resp-sharing-button__icon--solid
+											"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 24 24"
+											>
+												<path
+													d="M24 11.5c0-1.65-1.35-3-3-3-.96 0-1.86.48-2.42 1.24-1.64-1-3.75-1.64-6.07-1.72.08-1.1.4-3.05 1.52-3.7.72-.4 1.73-.24 3 .5C17.2 6.3 18.46 7.5 20 7.5c1.65 0 3-1.35 3-3s-1.35-3-3-3c-1.38 0-2.54.94-2.88 2.22-1.43-.72-2.64-.8-3.6-.25-1.64.94-1.95 3.47-2 4.55-2.33.08-4.45.7-6.1 1.72C4.86 8.98 3.96 8.5 3 8.5c-1.65 0-3 1.35-3 3 0 1.32.84 2.44 2.05 2.84-.03.22-.05.44-.05.66 0 3.86 4.5 7 10 7s10-3.14 10-7c0-.22-.02-.44-.05-.66 1.2-.4 2.05-1.54 2.05-2.84zM2.3 13.37C1.5 13.07 1 12.35 1 11.5c0-1.1.9-2 2-2 .64 0 1.22.32 1.6.82-1.1.85-1.92 1.9-2.3 3.05zm3.7.13c0-1.1.9-2 2-2s2 .9 2 2-.9 2-2 2-2-.9-2-2zm9.8 4.8c-1.08.63-2.42.96-3.8.96-1.4 0-2.74-.34-3.8-.95-.24-.13-.32-.44-.2-.68.15-.24.46-.32.7-.18 1.83 1.06 4.76 1.06 6.6 0 .23-.13.53-.05.67.2.14.23.06.54-.18.67zm.2-2.8c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm5.7-2.13c-.38-1.16-1.2-2.2-2.3-3.05.38-.5.97-.82 1.6-.82 1.1 0 2 .9 2 2 0 .84-.53 1.57-1.3 1.87z"
+												/>
+											</svg>
+										</div>
+										Reddit
+									</div>
 								</a>
 
 								<!-- Sharingbutton Facebook -->
-								<a class="resp-sharing-button__link" v-bind:href="'https://facebook.com/sharer/sharer.php?u='+ objectLink" target="_blank" rel="noopener" aria-label="Facebook">
-									<div class="resp-sharing-button resp-sharing-button--facebook resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
-										<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.77 7.46H14.5v-1.9c0-.9.6-1.1 1-1.1h3V.5h-4.33C10.24.5 9.5 3.44 9.5 5.32v2.15h-3v4h3v12h5v-12h3.85l.42-4z"/></svg></div>Facebook</div>
+								<a
+									class="resp-sharing-button__link"
+									v-bind:href="
+										'https://facebook.com/sharer/sharer.php?u=' +
+										objectLink
+									"
+									target="_blank"
+									rel="noopener"
+									aria-label="Facebook"
+								>
+									<div
+										class="
+											resp-sharing-button
+											resp-sharing-button--facebook
+											resp-sharing-button--medium
+										"
+									>
+										<div
+											aria-hidden="true"
+											class="
+												resp-sharing-button__icon
+												resp-sharing-button__icon--solid
+											"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 24 24"
+											>
+												<path
+													d="M18.77 7.46H14.5v-1.9c0-.9.6-1.1 1-1.1h3V.5h-4.33C10.24.5 9.5 3.44 9.5 5.32v2.15h-3v4h3v12h5v-12h3.85l.42-4z"
+												/>
+											</svg>
+										</div>
+										Facebook
+									</div>
 								</a>
 
 								<!-- Sharingbutton Twitter -->
-								<a class="resp-sharing-button__link" v-bind:href="'https://twitter.com/intent/tweet/?text=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;url='+ objectLink" target="_blank" rel="noopener" aria-label="Twitter">
-									<div class="resp-sharing-button resp-sharing-button--twitter resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
-										<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M23.44 4.83c-.8.37-1.5.38-2.22.02.93-.56.98-.96 1.32-2.02-.88.52-1.86.9-2.9 1.1-.82-.88-2-1.43-3.3-1.43-2.5 0-4.55 2.04-4.55 4.54 0 .36.03.7.1 1.04-3.77-.2-7.12-2-9.36-4.75-.4.67-.6 1.45-.6 2.3 0 1.56.8 2.95 2 3.77-.74-.03-1.44-.23-2.05-.57v.06c0 2.2 1.56 4.03 3.64 4.44-.67.2-1.37.2-2.06.08.58 1.8 2.26 3.12 4.25 3.16C5.78 18.1 3.37 18.74 1 18.46c2 1.3 4.4 2.04 6.97 2.04 8.35 0 12.92-6.92 12.92-12.93 0-.2 0-.4-.02-.6.9-.63 1.96-1.22 2.56-2.14z"/></svg></div>Twitter</div>
+								<a
+									class="resp-sharing-button__link"
+									v-bind:href="
+										'https://twitter.com/intent/tweet/?text=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;url=' +
+										objectLink
+									"
+									target="_blank"
+									rel="noopener"
+									aria-label="Twitter"
+								>
+									<div
+										class="
+											resp-sharing-button
+											resp-sharing-button--twitter
+											resp-sharing-button--medium
+										"
+									>
+										<div
+											aria-hidden="true"
+											class="
+												resp-sharing-button__icon
+												resp-sharing-button__icon--solid
+											"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 24 24"
+											>
+												<path
+													d="M23.44 4.83c-.8.37-1.5.38-2.22.02.93-.56.98-.96 1.32-2.02-.88.52-1.86.9-2.9 1.1-.82-.88-2-1.43-3.3-1.43-2.5 0-4.55 2.04-4.55 4.54 0 .36.03.7.1 1.04-3.77-.2-7.12-2-9.36-4.75-.4.67-.6 1.45-.6 2.3 0 1.56.8 2.95 2 3.77-.74-.03-1.44-.23-2.05-.57v.06c0 2.2 1.56 4.03 3.64 4.44-.67.2-1.37.2-2.06.08.58 1.8 2.26 3.12 4.25 3.16C5.78 18.1 3.37 18.74 1 18.46c2 1.3 4.4 2.04 6.97 2.04 8.35 0 12.92-6.92 12.92-12.93 0-.2 0-.4-.02-.6.9-.63 1.96-1.22 2.56-2.14z"
+												/>
+											</svg>
+										</div>
+										Twitter
+									</div>
 								</a>
 
 								<!-- Sharingbutton Hacker News -->
-								<a class="resp-sharing-button__link" v-bind:href="'https://news.ycombinator.com/submitlink?u='+ objectLink +'&amp;t=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage'" target="_blank" rel="noopener" aria-label="Hacker News">
-									<div class="resp-sharing-button resp-sharing-button--hackernews resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
-											<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 140"><path fill-rule="evenodd" d="M60.94 82.314L17 0h20.08l25.85 52.093c.397.927.86 1.888 1.39 2.883.53.994.995 2.02 1.393 3.08.265.4.463.764.596 1.095.13.334.262.63.395.898.662 1.325 1.26 2.618 1.79 3.877.53 1.26.993 2.42 1.39 3.48 1.06-2.254 2.22-4.673 3.48-7.258 1.26-2.585 2.552-5.27 3.877-8.052L103.49 0h18.69L77.84 83.308v53.087h-16.9v-54.08z"></path></svg></div>Hacker News</div>
+								<a
+									class="resp-sharing-button__link"
+									v-bind:href="
+										'https://news.ycombinator.com/submitlink?u=' +
+										objectLink +
+										'&amp;t=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage'
+									"
+									target="_blank"
+									rel="noopener"
+									aria-label="Hacker News"
+								>
+									<div
+										class="
+											resp-sharing-button
+											resp-sharing-button--hackernews
+											resp-sharing-button--medium
+										"
+									>
+										<div
+											aria-hidden="true"
+											class="
+												resp-sharing-button__icon
+												resp-sharing-button__icon--solid
+											"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 140 140"
+											>
+												<path
+													fill-rule="evenodd"
+													d="M60.94 82.314L17 0h20.08l25.85 52.093c.397.927.86 1.888 1.39 2.883.53.994.995 2.02 1.393 3.08.265.4.463.764.596 1.095.13.334.262.63.395.898.662 1.325 1.26 2.618 1.79 3.877.53 1.26.993 2.42 1.39 3.48 1.06-2.254 2.22-4.673 3.48-7.258 1.26-2.585 2.552-5.27 3.877-8.052L103.49 0h18.69L77.84 83.308v53.087h-16.9v-54.08z"
+												></path>
+											</svg>
+										</div>
+										Hacker News
+									</div>
 								</a>
 
 								<!-- Sharingbutton LinkedIn -->
-								<a class="resp-sharing-button__link" v-bind:href="'https://www.linkedin.com/shareArticle?mini=true&amp;url='+ objectLink +'&amp;title=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;summary=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;source='+ objectLink" target="_blank" rel="noopener" aria-label="LinkedIn">
-								  <div class="resp-sharing-button resp-sharing-button--linkedin resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
-								    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.5 21.5h-5v-13h5v13zM4 6.5C2.5 6.5 1.5 5.3 1.5 4s1-2.4 2.5-2.4c1.6 0 2.5 1 2.6 2.5 0 1.4-1 2.5-2.6 2.5zm11.5 6c-1 0-2 1-2 2v7h-5v-13h5V10s1.6-1.5 4-1.5c3 0 5 2.2 5 6.3v6.7h-5v-7c0-1-1-2-2-2z"/></svg></div>LinkedIn</div>
+								<a
+									class="resp-sharing-button__link"
+									v-bind:href="
+										'https://www.linkedin.com/shareArticle?mini=true&amp;url=' +
+										objectLink +
+										'&amp;title=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;summary=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;source=' +
+										objectLink
+									"
+									target="_blank"
+									rel="noopener"
+									aria-label="LinkedIn"
+								>
+									<div
+										class="
+											resp-sharing-button
+											resp-sharing-button--linkedin
+											resp-sharing-button--medium
+										"
+									>
+										<div
+											aria-hidden="true"
+											class="
+												resp-sharing-button__icon
+												resp-sharing-button__icon--solid
+											"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 24 24"
+											>
+												<path
+													d="M6.5 21.5h-5v-13h5v13zM4 6.5C2.5 6.5 1.5 5.3 1.5 4s1-2.4 2.5-2.4c1.6 0 2.5 1 2.6 2.5 0 1.4-1 2.5-2.6 2.5zm11.5 6c-1 0-2 1-2 2v7h-5v-13h5V10s1.6-1.5 4-1.5c3 0 5 2.2 5 6.3v6.7h-5v-7c0-1-1-2-2-2z"
+												/>
+											</svg>
+										</div>
+										LinkedIn
+									</div>
 								</a>
 
 								<!-- Sharingbutton Telegram -->
-								<a class="resp-sharing-button__link" v-bind:href="'https://telegram.me/share/url?text=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;url='+ objectLink" target="_blank" rel="noopener" aria-label="Telegram">
-								  <div class="resp-sharing-button resp-sharing-button--telegram resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
-								      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.707 8.475C.275 8.64 0 9.508 0 9.508s.284.867.718 1.03l5.09 1.897 1.986 6.38a1.102 1.102 0 0 0 1.75.527l2.96-2.41a.405.405 0 0 1 .494-.013l5.34 3.87a1.1 1.1 0 0 0 1.046.135 1.1 1.1 0 0 0 .682-.803l3.91-18.795A1.102 1.102 0 0 0 22.5.075L.706 8.475z"/></svg></div>Telegram</div>
+								<a
+									class="resp-sharing-button__link"
+									v-bind:href="
+										'https://telegram.me/share/url?text=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;url=' +
+										objectLink
+									"
+									target="_blank"
+									rel="noopener"
+									aria-label="Telegram"
+								>
+									<div
+										class="
+											resp-sharing-button
+											resp-sharing-button--telegram
+											resp-sharing-button--medium
+										"
+									>
+										<div
+											aria-hidden="true"
+											class="
+												resp-sharing-button__icon
+												resp-sharing-button__icon--solid
+											"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 24 24"
+											>
+												<path
+													d="M.707 8.475C.275 8.64 0 9.508 0 9.508s.284.867.718 1.03l5.09 1.897 1.986 6.38a1.102 1.102 0 0 0 1.75.527l2.96-2.41a.405.405 0 0 1 .494-.013l5.34 3.87a1.1 1.1 0 0 0 1.046.135 1.1 1.1 0 0 0 .682-.803l3.91-18.795A1.102 1.102 0 0 0 22.5.075L.706 8.475z"
+												/>
+											</svg>
+										</div>
+										Telegram
+									</div>
 								</a>
 
 								<!-- Sharingbutton WhatsApp -->
-								<a class="resp-sharing-button__link" v-bind:href="'whatsapp://send?text=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage%20'+ objectLink" target="_blank" rel="noopener" aria-label="WhatsApp">
-								  <div class="resp-sharing-button resp-sharing-button--whatsapp resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
-								    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.1 3.9C17.9 1.7 15 .5 12 .5 5.8.5.7 5.6.7 11.9c0 2 .5 3.9 1.5 5.6L.6 23.4l6-1.6c1.6.9 3.5 1.3 5.4 1.3 6.3 0 11.4-5.1 11.4-11.4-.1-2.8-1.2-5.7-3.3-7.8zM12 21.4c-1.7 0-3.3-.5-4.8-1.3l-.4-.2-3.5 1 1-3.4L4 17c-1-1.5-1.4-3.2-1.4-5.1 0-5.2 4.2-9.4 9.4-9.4 2.5 0 4.9 1 6.7 2.8 1.8 1.8 2.8 4.2 2.8 6.7-.1 5.2-4.3 9.4-9.5 9.4zm5.1-7.1c-.3-.1-1.7-.9-1.9-1-.3-.1-.5-.1-.7.1-.2.3-.8 1-.9 1.1-.2.2-.3.2-.6.1s-1.2-.5-2.3-1.4c-.9-.8-1.4-1.7-1.6-2-.2-.3 0-.5.1-.6s.3-.3.4-.5c.2-.1.3-.3.4-.5.1-.2 0-.4 0-.5C10 9 9.3 7.6 9 7c-.1-.4-.4-.3-.5-.3h-.6s-.4.1-.7.3c-.3.3-1 1-1 2.4s1 2.8 1.1 3c.1.2 2 3.1 4.9 4.3.7.3 1.2.5 1.6.6.7.2 1.3.2 1.8.1.6-.1 1.7-.7 1.9-1.3.2-.7.2-1.2.2-1.3-.1-.3-.3-.4-.6-.5z"/></svg></div>WhatsApp</div>
+								<a
+									class="resp-sharing-button__link"
+									v-bind:href="
+										'whatsapp://send?text=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage%20' +
+										objectLink
+									"
+									target="_blank"
+									rel="noopener"
+									aria-label="WhatsApp"
+								>
+									<div
+										class="
+											resp-sharing-button
+											resp-sharing-button--whatsapp
+											resp-sharing-button--medium
+										"
+									>
+										<div
+											aria-hidden="true"
+											class="
+												resp-sharing-button__icon
+												resp-sharing-button__icon--solid
+											"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 24 24"
+											>
+												<path
+													d="M20.1 3.9C17.9 1.7 15 .5 12 .5 5.8.5.7 5.6.7 11.9c0 2 .5 3.9 1.5 5.6L.6 23.4l6-1.6c1.6.9 3.5 1.3 5.4 1.3 6.3 0 11.4-5.1 11.4-11.4-.1-2.8-1.2-5.7-3.3-7.8zM12 21.4c-1.7 0-3.3-.5-4.8-1.3l-.4-.2-3.5 1 1-3.4L4 17c-1-1.5-1.4-3.2-1.4-5.1 0-5.2 4.2-9.4 9.4-9.4 2.5 0 4.9 1 6.7 2.8 1.8 1.8 2.8 4.2 2.8 6.7-.1 5.2-4.3 9.4-9.5 9.4zm5.1-7.1c-.3-.1-1.7-.9-1.9-1-.3-.1-.5-.1-.7.1-.2.3-.8 1-.9 1.1-.2.2-.3.2-.6.1s-1.2-.5-2.3-1.4c-.9-.8-1.4-1.7-1.6-2-.2-.3 0-.5.1-.6s.3-.3.4-.5c.2-.1.3-.3.4-.5.1-.2 0-.4 0-.5C10 9 9.3 7.6 9 7c-.1-.4-.4-.3-.5-.3h-.6s-.4.1-.7.3c-.3.3-1 1-1 2.4s1 2.8 1.1 3c.1.2 2 3.1 4.9 4.3.7.3 1.2.5 1.6.6.7.2 1.3.2 1.8.1.6-.1 1.7-.7 1.9-1.3.2-.7.2-1.2.2-1.3-.1-.3-.3-.4-.6-.5z"
+												/>
+											</svg>
+										</div>
+										WhatsApp
+									</div>
 								</a>
 
 								<!-- Sharingbutton E-Mail -->
-								<a class="resp-sharing-button__link" v-bind:href="'mailto:?subject=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;body='+ objectLink" target="_self" rel="noopener" aria-label="E-Mail">
-									<div class="resp-sharing-button resp-sharing-button--email resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
-										<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M22 4H2C.9 4 0 4.9 0 6v12c0 1.1.9 2 2 2h20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zM7.25 14.43l-3.5 2c-.08.05-.17.07-.25.07-.17 0-.34-.1-.43-.25-.14-.24-.06-.55.18-.68l3.5-2c.24-.14.55-.06.68.18.14.24.06.55-.18.68zm4.75.07c-.1 0-.2-.03-.27-.08l-8.5-5.5c-.23-.15-.3-.46-.15-.7.15-.22.46-.3.7-.14L12 13.4l8.23-5.32c.23-.15.54-.08.7.15.14.23.07.54-.16.7l-8.5 5.5c-.08.04-.17.07-.27.07zm8.93 1.75c-.1.16-.26.25-.43.25-.08 0-.17-.02-.25-.07l-3.5-2c-.24-.13-.32-.44-.18-.68s.44-.32.68-.18l3.5 2c.24.13.32.44.18.68z"/></svg></div>E-Mail</div>
+								<a
+									class="resp-sharing-button__link"
+									v-bind:href="
+										'mailto:?subject=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;body=' +
+										objectLink
+									"
+									target="_self"
+									rel="noopener"
+									aria-label="E-Mail"
+								>
+									<div
+										class="
+											resp-sharing-button
+											resp-sharing-button--email
+											resp-sharing-button--medium
+										"
+									>
+										<div
+											aria-hidden="true"
+											class="
+												resp-sharing-button__icon
+												resp-sharing-button__icon--solid
+											"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 24 24"
+											>
+												<path
+													d="M22 4H2C.9 4 0 4.9 0 6v12c0 1.1.9 2 2 2h20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zM7.25 14.43l-3.5 2c-.08.05-.17.07-.25.07-.17 0-.34-.1-.43-.25-.14-.24-.06-.55.18-.68l3.5-2c.24-.14.55-.06.68.18.14.24.06.55-.18.68zm4.75.07c-.1 0-.2-.03-.27-.08l-8.5-5.5c-.23-.15-.3-.46-.15-.7.15-.22.46-.3.7-.14L12 13.4l8.23-5.32c.23-.15.54-.08.7.15.14.23.07.54-.16.7l-8.5 5.5c-.08.04-.17.07-.27.07zm8.93 1.75c-.1.16-.26.25-.43.25-.08 0-.17-.02-.25-.07l-3.5-2c-.24-.13-.32-.44-.18-.68s.44-.32.68-.18l3.5 2c.24.13.32.44.18.68z"
+												/>
+											</svg>
+										</div>
+										E-Mail
+									</div>
 								</a>
 							</div>
 
-							<hr>
+							<hr />
 
 							<p class="my-4">Or copy link</p>
 
@@ -304,19 +566,22 @@
 									aria-describedby="btn-copy-link"
 									readonly
 								/>
-							  <div class="input-group-append">
+								<div class="input-group-append">
 									<button
 										v-on:click="copy"
 										type="button"
 										name="copy"
-										class="btn btn-outline-secondary btn-copy-link"
+										class="
+											btn
+											btn-outline-secondary
+											btn-copy-link
+										"
 										id="btn-copy-link"
 									>
 										{{ this.copyText }}
 									</button>
-							  </div>
+								</div>
 							</div>
-
 						</div>
 
 						<!-- <button

--- a/src/components/FileShareModal.vue
+++ b/src/components/FileShareModal.vue
@@ -8,17 +8,6 @@
 	font-weight: bold;
 }
 
-.btn-copy {
-	position: absolute;
-	bottom: 74px;
-	right: 22px;
-	color: #0068dc;
-}
-
-#url {
-	padding-right: 30%;
-}
-
 .closex {
 	cursor: pointer;
 }
@@ -30,6 +19,199 @@
 #backdrop {
 	z-index: 1060 !important;
 }
+
+.btn-copy-link {
+	border-top-right-radius: 4px;
+	border-bottom-right-radius: 4px;
+	font-size: 14px;
+	padding: 0 16px;
+}
+
+/* Social Share Buttons Styles */
+
+.resp-sharing-button__link,
+.resp-sharing-button__icon {
+  display: inline-block;
+}
+
+.resp-sharing-button__link {
+  text-decoration: none;
+  color: #fff;
+	margin-right: 1em;
+  margin-bottom: 1em;
+}
+
+.resp-sharing-button {
+  border-radius: 5px;
+  transition: 25ms ease-out;
+  padding: 0.5em 0.75em;
+	font-size: 12px;
+}
+
+.resp-sharing-button__icon svg {
+  width: 1em;
+  height: 1em;
+  margin-right: 0.4em;
+  vertical-align: middle;
+}
+
+.resp-sharing-button--small svg {
+  margin: 0;
+  vertical-align: middle;
+}
+
+.resp-sharing-button__icon--solid,
+.resp-sharing-button__icon--solidcircle {
+  fill: #fff;
+  stroke: none;
+}
+
+.resp-sharing-button--twitter {
+  background-color: #55acee;
+}
+
+.resp-sharing-button--twitter:hover {
+  background-color: #2795e9;
+}
+
+.resp-sharing-button--facebook {
+  background-color: #3b5998;
+}
+
+.resp-sharing-button--facebook:hover {
+  background-color: #2d4373;
+}
+
+.resp-sharing-button--reddit {
+  background-color: #5f99cf;
+}
+
+.resp-sharing-button--reddit:hover {
+  background-color: #3a80c1;
+}
+
+.resp-sharing-button--linkedin {
+  background-color: #0077b5;
+}
+
+.resp-sharing-button--linkedin:hover {
+  background-color: #046293;
+}
+
+.resp-sharing-button--email {
+  background-color: #777
+}
+
+.resp-sharing-button--email:hover {
+  background-color: #5e5e5e;
+}
+
+.resp-sharing-button--hackernews {
+	background-color: #FF6600;
+}
+.resp-sharing-button--hackernews:hover, .resp-sharing-button--hackernews:focus {   background-color: #FB6200 }
+
+.resp-sharing-button--facebook {
+  background-color: #3b5998;
+  border-color: #3b5998;
+}
+
+.resp-sharing-button--facebook:hover,
+.resp-sharing-button--facebook:active {
+  background-color: #2d4373;
+  border-color: #2d4373;
+}
+
+.resp-sharing-button--twitter {
+  background-color: #55acee;
+  border-color: #55acee;
+}
+
+.resp-sharing-button--twitter:hover,
+.resp-sharing-button--twitter:active {
+  background-color: #2795e9;
+  border-color: #2795e9;
+}
+
+.resp-sharing-button--email {
+  background-color: #777777;
+  border-color: #777777;
+}
+
+.resp-sharing-button--email:hover,
+.resp-sharing-button--email:active {
+  background-color: #5e5e5e;
+  border-color: #5e5e5e;
+}
+
+.resp-sharing-button--reddit {
+  background-color: #5f99cf;
+  border-color: #5f99cf;
+}
+
+.resp-sharing-button--reddit:hover,
+.resp-sharing-button--reddit:active {
+  background-color: #3a80c1;
+  border-color: #3a80c1;
+}
+
+.resp-sharing-button--hackernews {
+  background-color: #FF6600;
+  border-color: #FF6600;
+}
+
+.resp-sharing-button--hackernews:hover
+.resp-sharing-button--hackernews:active {
+  background-color: #FB6200;
+  border-color: #FB6200;
+}
+
+.resp-sharing-button--whatsapp {
+  background-color: #25D366;
+  border-color: #25D366;
+}
+
+.resp-sharing-button--whatsapp:hover,
+.resp-sharing-button--whatsapp:active {
+  background-color: #1DA851;
+  border-color: #1DA851;
+}
+
+.resp-sharing-button--whatsapp {
+  background-color: #25D366
+}
+
+.resp-sharing-button--whatsapp:hover {
+  background-color: #1da851
+}
+
+.resp-sharing-button--linkedin {
+  background-color: #0077b5;
+  border-color: #0077b5;
+}
+
+.resp-sharing-button--linkedin:hover,
+.resp-sharing-button--linkedin:active {
+  background-color: #046293;
+  border-color: #046293;
+}
+
+.resp-sharing-button--linkedin {
+  background-color: #0077b5
+}
+
+.resp-sharing-button--linkedin:hover {
+  background-color: #046293
+}
+
+.resp-sharing-button--telegram {
+  background-color: #54A9EB;
+}
+
+.resp-sharing-button--telegram:hover {
+  background-color: #4B97D1;
+}
+
 </style>
 
 <template>
@@ -43,67 +225,109 @@
 		>
 			<div class="modal-dialog modal-dialog-centered">
 				<div
-					class="modal-content text-center border-0 p-2 p-sm-4 p-md-5"
+					class="modal-content text-center border-0 p-2 p-sm-4"
 				>
-					<div class="modal-body pt-0">
-						<div class="d-flex justify-content-end">
-							<svg
-								v-on:click="close"
-								xmlns="http://www.w3.org/2000/svg"
-								width="2em"
-								height="2em"
-								fill="#6e6e6e"
-								class="bi bi-x mb-2 closex"
-								viewBox="0 0 16 16"
-							>
-								<path
-									d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"
+					<div class="modal-header border-0">
+						<h5 class="modal-title pt-2">Share</h5>
+						<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+							<span aria-hidden="true">&times;</span>
+						</button>
+					</div>
+					<div class="modal-body pt-0 text-left">
+
+						<div>
+
+							<hr>
+							<div class="social-share-icons my-4">
+
+								<p>Share this link via</p>
+
+								<!-- Sharingbutton Reddit -->
+								<a class="resp-sharing-button__link" v-bind:href="'https://reddit.com/submit/?url='+ objectLink +'&amp;resubmit=true&amp;title=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage'" target="_blank" rel="noopener" aria-label="Reddit">
+									<div class="resp-sharing-button resp-sharing-button--reddit resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+										<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M24 11.5c0-1.65-1.35-3-3-3-.96 0-1.86.48-2.42 1.24-1.64-1-3.75-1.64-6.07-1.72.08-1.1.4-3.05 1.52-3.7.72-.4 1.73-.24 3 .5C17.2 6.3 18.46 7.5 20 7.5c1.65 0 3-1.35 3-3s-1.35-3-3-3c-1.38 0-2.54.94-2.88 2.22-1.43-.72-2.64-.8-3.6-.25-1.64.94-1.95 3.47-2 4.55-2.33.08-4.45.7-6.1 1.72C4.86 8.98 3.96 8.5 3 8.5c-1.65 0-3 1.35-3 3 0 1.32.84 2.44 2.05 2.84-.03.22-.05.44-.05.66 0 3.86 4.5 7 10 7s10-3.14 10-7c0-.22-.02-.44-.05-.66 1.2-.4 2.05-1.54 2.05-2.84zM2.3 13.37C1.5 13.07 1 12.35 1 11.5c0-1.1.9-2 2-2 .64 0 1.22.32 1.6.82-1.1.85-1.92 1.9-2.3 3.05zm3.7.13c0-1.1.9-2 2-2s2 .9 2 2-.9 2-2 2-2-.9-2-2zm9.8 4.8c-1.08.63-2.42.96-3.8.96-1.4 0-2.74-.34-3.8-.95-.24-.13-.32-.44-.2-.68.15-.24.46-.32.7-.18 1.83 1.06 4.76 1.06 6.6 0 .23-.13.53-.05.67.2.14.23.06.54-.18.67zm.2-2.8c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm5.7-2.13c-.38-1.16-1.2-2.2-2.3-3.05.38-.5.97-.82 1.6-.82 1.1 0 2 .9 2 2 0 .84-.53 1.57-1.3 1.87z"/></svg></div>Reddit</div>
+								</a>
+
+								<!-- Sharingbutton Facebook -->
+								<a class="resp-sharing-button__link" v-bind:href="'https://facebook.com/sharer/sharer.php?u='+ objectLink" target="_blank" rel="noopener" aria-label="Facebook">
+									<div class="resp-sharing-button resp-sharing-button--facebook resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+										<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.77 7.46H14.5v-1.9c0-.9.6-1.1 1-1.1h3V.5h-4.33C10.24.5 9.5 3.44 9.5 5.32v2.15h-3v4h3v12h5v-12h3.85l.42-4z"/></svg></div>Facebook</div>
+								</a>
+
+								<!-- Sharingbutton Twitter -->
+								<a class="resp-sharing-button__link" v-bind:href="'https://twitter.com/intent/tweet/?text=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;url='+ objectLink" target="_blank" rel="noopener" aria-label="Twitter">
+									<div class="resp-sharing-button resp-sharing-button--twitter resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+										<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M23.44 4.83c-.8.37-1.5.38-2.22.02.93-.56.98-.96 1.32-2.02-.88.52-1.86.9-2.9 1.1-.82-.88-2-1.43-3.3-1.43-2.5 0-4.55 2.04-4.55 4.54 0 .36.03.7.1 1.04-3.77-.2-7.12-2-9.36-4.75-.4.67-.6 1.45-.6 2.3 0 1.56.8 2.95 2 3.77-.74-.03-1.44-.23-2.05-.57v.06c0 2.2 1.56 4.03 3.64 4.44-.67.2-1.37.2-2.06.08.58 1.8 2.26 3.12 4.25 3.16C5.78 18.1 3.37 18.74 1 18.46c2 1.3 4.4 2.04 6.97 2.04 8.35 0 12.92-6.92 12.92-12.93 0-.2 0-.4-.02-.6.9-.63 1.96-1.22 2.56-2.14z"/></svg></div>Twitter</div>
+								</a>
+
+								<!-- Sharingbutton Hacker News -->
+								<a class="resp-sharing-button__link" v-bind:href="'https://news.ycombinator.com/submitlink?u='+ objectLink +'&amp;t=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage'" target="_blank" rel="noopener" aria-label="Hacker News">
+									<div class="resp-sharing-button resp-sharing-button--hackernews resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+											<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 140"><path fill-rule="evenodd" d="M60.94 82.314L17 0h20.08l25.85 52.093c.397.927.86 1.888 1.39 2.883.53.994.995 2.02 1.393 3.08.265.4.463.764.596 1.095.13.334.262.63.395.898.662 1.325 1.26 2.618 1.79 3.877.53 1.26.993 2.42 1.39 3.48 1.06-2.254 2.22-4.673 3.48-7.258 1.26-2.585 2.552-5.27 3.877-8.052L103.49 0h18.69L77.84 83.308v53.087h-16.9v-54.08z"></path></svg></div>Hacker News</div>
+								</a>
+
+								<!-- Sharingbutton LinkedIn -->
+								<a class="resp-sharing-button__link" v-bind:href="'https://www.linkedin.com/shareArticle?mini=true&amp;url='+ objectLink +'&amp;title=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;summary=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;source='+ objectLink" target="_blank" rel="noopener" aria-label="LinkedIn">
+								  <div class="resp-sharing-button resp-sharing-button--linkedin resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+								    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.5 21.5h-5v-13h5v13zM4 6.5C2.5 6.5 1.5 5.3 1.5 4s1-2.4 2.5-2.4c1.6 0 2.5 1 2.6 2.5 0 1.4-1 2.5-2.6 2.5zm11.5 6c-1 0-2 1-2 2v7h-5v-13h5V10s1.6-1.5 4-1.5c3 0 5 2.2 5 6.3v6.7h-5v-7c0-1-1-2-2-2z"/></svg></div>LinkedIn</div>
+								</a>
+
+								<!-- Sharingbutton Telegram -->
+								<a class="resp-sharing-button__link" v-bind:href="'https://telegram.me/share/url?text=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;url='+ objectLink" target="_blank" rel="noopener" aria-label="Telegram">
+								  <div class="resp-sharing-button resp-sharing-button--telegram resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+								      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.707 8.475C.275 8.64 0 9.508 0 9.508s.284.867.718 1.03l5.09 1.897 1.986 6.38a1.102 1.102 0 0 0 1.75.527l2.96-2.41a.405.405 0 0 1 .494-.013l5.34 3.87a1.1 1.1 0 0 0 1.046.135 1.1 1.1 0 0 0 .682-.803l3.91-18.795A1.102 1.102 0 0 0 22.5.075L.706 8.475z"/></svg></div>Telegram</div>
+								</a>
+
+								<!-- Sharingbutton WhatsApp -->
+								<a class="resp-sharing-button__link" v-bind:href="'whatsapp://send?text=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage%20'+ objectLink" target="_blank" rel="noopener" aria-label="WhatsApp">
+								  <div class="resp-sharing-button resp-sharing-button--whatsapp resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+								    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.1 3.9C17.9 1.7 15 .5 12 .5 5.8.5.7 5.6.7 11.9c0 2 .5 3.9 1.5 5.6L.6 23.4l6-1.6c1.6.9 3.5 1.3 5.4 1.3 6.3 0 11.4-5.1 11.4-11.4-.1-2.8-1.2-5.7-3.3-7.8zM12 21.4c-1.7 0-3.3-.5-4.8-1.3l-.4-.2-3.5 1 1-3.4L4 17c-1-1.5-1.4-3.2-1.4-5.1 0-5.2 4.2-9.4 9.4-9.4 2.5 0 4.9 1 6.7 2.8 1.8 1.8 2.8 4.2 2.8 6.7-.1 5.2-4.3 9.4-9.5 9.4zm5.1-7.1c-.3-.1-1.7-.9-1.9-1-.3-.1-.5-.1-.7.1-.2.3-.8 1-.9 1.1-.2.2-.3.2-.6.1s-1.2-.5-2.3-1.4c-.9-.8-1.4-1.7-1.6-2-.2-.3 0-.5.1-.6s.3-.3.4-.5c.2-.1.3-.3.4-.5.1-.2 0-.4 0-.5C10 9 9.3 7.6 9 7c-.1-.4-.4-.3-.5-.3h-.6s-.4.1-.7.3c-.3.3-1 1-1 2.4s1 2.8 1.1 3c.1.2 2 3.1 4.9 4.3.7.3 1.2.5 1.6.6.7.2 1.3.2 1.8.1.6-.1 1.7-.7 1.9-1.3.2-.7.2-1.2.2-1.3-.1-.3-.3-.4-.6-.5z"/></svg></div>WhatsApp</div>
+								</a>
+
+								<!-- Sharingbutton E-Mail -->
+								<a class="resp-sharing-button__link" v-bind:href="'mailto:?subject=Shared%20using%20Storj%20Decentralized%20Cloud%20Storage&amp;body='+ objectLink" target="_self" rel="noopener" aria-label="E-Mail">
+									<div class="resp-sharing-button resp-sharing-button--email resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+										<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M22 4H2C.9 4 0 4.9 0 6v12c0 1.1.9 2 2 2h20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zM7.25 14.43l-3.5 2c-.08.05-.17.07-.25.07-.17 0-.34-.1-.43-.25-.14-.24-.06-.55.18-.68l3.5-2c.24-.14.55-.06.68.18.14.24.06.55-.18.68zm4.75.07c-.1 0-.2-.03-.27-.08l-8.5-5.5c-.23-.15-.3-.46-.15-.7.15-.22.46-.3.7-.14L12 13.4l8.23-5.32c.23-.15.54-.08.7.15.14.23.07.54-.16.7l-8.5 5.5c-.08.04-.17.07-.27.07zm8.93 1.75c-.1.16-.26.25-.43.25-.08 0-.17-.02-.25-.07l-3.5-2c-.24-.13-.32-.44-.18-.68s.44-.32.68-.18l3.5 2c.24.13.32.44.18.68z"/></svg></div>E-Mail</div>
+								</a>
+							</div>
+
+							<hr>
+
+							<p class="my-4">Or copy link</p>
+
+							<div class="input-group my-4">
+								<input
+									class="form-control"
+									type="url"
+									id="url"
+									v-bind:value="objectLink"
+									aria-describedby="btn-copy-link"
+									readonly
 								/>
-							</svg>
-						</div>
-						<h5
-							class="modal-title mx-auto mb-3"
-							id="shareModalLabel"
-						>
-							Share Object
-						</h5>
+							  <div class="input-group-append">
+									<button
+										v-on:click="copy"
+										type="button"
+										name="copy"
+										class="btn btn-outline-secondary btn-copy-link"
+										id="btn-copy-link"
+									>
+										{{ this.copyText }}
+									</button>
+							  </div>
+							</div>
 
-						<div v-if="objectLink">
-							<input
-								class="form-control form-control-lg mt-4"
-								type="url"
-								id="url"
-								v-bind:value="objectLink"
-								readonly
-							/>
-							<button
-								v-on:click="copy"
-								type="button"
-								name="copy"
-								class="btn btn-outline-primary btn-copy"
-							>
-								{{ copyText }}
-							</button>
 						</div>
 
-						<button
+						<!-- <button
 							v-else
 							type="button"
 							name="copy"
-							class="btn btn-outline-primary btn-block share-btn"
+							class="btn btn-primary btn-block share-btn my-4"
 							v-on:click="getSharedLink"
 						>
 							Generate Share Link
-						</button>
-
-						<button
-							type="button"
-							class="btn btn-primary btn-block mt-3"
-							data-dismiss="modal"
-							v-on:click="close"
-						>
-							Done
-						</button>
+						</button> -->
 					</div>
 				</div>
 			</div>
@@ -117,7 +341,7 @@ export default {
 	name: "FileShareModal",
 	data: () => ({
 		objectLink: null,
-		copyText: "Copy Link"
+		copyText: "Copy"
 	}),
 	computed: {
 		filePath() {


### PR DESCRIPTION
Updated the sharing ui and modal, also adding social share functionality without javascript and without any tracking.

<img width="1662" alt="social-share-link" src="https://user-images.githubusercontent.com/3217669/124497360-05bfa280-ddbb-11eb-9dd0-de6e08112d11.png">

The only thing left is to remove the Generate Share Link step when you open the sharing modal, so that it generates the links when you open up the modal instead of having to click a button first.